### PR TITLE
fix(ts): fixs the use of @ts-ignore when passing custom hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "render-hooks",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Inline render-block-stable React hooks",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -51,13 +51,35 @@ type HooksMap = Record<string, any> & {
   length?: never; // This prevents arrays
 };
 
+type RenderHooksProps<TValue extends HooksMap> = {
+  /**
+   * Optionally pass in a map of hooks to use.
+   * 
+   * @example
+   * 
+   * ```tsx
+   * <RenderHooks hooks={{
+   *   useSomething: () => 'something',
+   * }}>
+   *   {({ useSomething }) => {
+   *     const something = useSomething();
+   *     return (
+   *       <>
+   *         <div>{something}</div>
+   *       </>
+   *     );
+   *   }}
+   * </RenderHooks>
+   * ```
+   */
+  hooks?: TValue;
+  children: (helpers: CoreHelpers & TValue) => React.ReactNode;
+}
+
 export default function RenderHooks<TValue extends HooksMap>({
   children,
   hooks = {} as TValue,
-}: {
-  hooks?: TValue;
-  children: (helpers: CoreHelpers & TValue) => React.ReactNode;
-}): React.ReactElement {
+}: RenderHooksProps<TValue>): React.ReactElement {
   const helpers = React.useMemo(
     () => ({ ...coreHelpers, ...(hooks ?? {}) }),
     [hooks],

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -47,16 +47,22 @@ type CoreHelpers = typeof coreHelpers;
 /* ----------------------------------------------------------- *
  * 4 ▸ default component                                       *
  * ----------------------------------------------------------- */
-export default function RenderHooks<
-  TValue extends Record<string, Fn> = {},
->(props: {
+type HooksMap = Record<string, any> & {
+  length?: never; // This prevents arrays
+};
+
+export default function RenderHooks<TValue extends HooksMap>({
+  children,
+  hooks = {} as TValue,
+}: {
   hooks?: TValue;
   children: (helpers: CoreHelpers & TValue) => React.ReactNode;
 }): React.ReactElement {
-  const { hooks, children } = props;
   const helpers = React.useMemo(
     () => ({ ...coreHelpers, ...(hooks ?? {}) }),
     [hooks],
   ) as CoreHelpers & TValue;
+
   return <>{children(helpers)}</>;
 }
+

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -47,9 +47,7 @@ type CoreHelpers = typeof coreHelpers;
 /* ----------------------------------------------------------- *
  * 4 ▸ default component                                       *
  * ----------------------------------------------------------- */
-type HooksMap = Record<string, any> & {
-  length?: never; // This prevents arrays
-};
+type HooksMap = Record<string, any>
 
 type RenderHooksProps<TValue extends HooksMap> = {
   /**
@@ -72,7 +70,9 @@ type RenderHooksProps<TValue extends HooksMap> = {
    * </RenderHooks>
    * ```
    */
-  hooks?: TValue;
+  hooks?: {
+    [K in keyof TValue]: TValue[K] extends Fn ? TValue[K] : `Please provide a valid function`
+  }
   children: (helpers: CoreHelpers & TValue) => React.ReactNode;
 }
 

--- a/src/stories/02-CustomHooks.stories.tsx
+++ b/src/stories/02-CustomHooks.stories.tsx
@@ -28,7 +28,6 @@ const useDebounce = <T,>(value: T, delay: number): T => {
 export function CustomHooksExample() {
   return (
     <$ hooks={{ useToggle, useDebounce }}>
-      {/* @ts-ignore */}
       {({ useToggle, useDebounce, useState }) => { // Added useState for completeness
         const [open, toggle] = useToggle(false);
         const dOpen = useDebounce(open, 250);


### PR DESCRIPTION
Hi there! First of all, I really loved the project.

Noticed that in the examples, you’re using `@ts-ignore` because of the custom hooks. This PR address that. It is not be the most elegant solution, but it works well 😬.